### PR TITLE
Add callback support (createItemDefaults)

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,12 +501,22 @@ const itemDefaults = createItemDefaults({
     someValue: true
   }
 })
+
+// You can also use a function to create defaults dynamically.
+const itemDefaults2 = createItemDefaults<Meta>((item) => ({
+  elementAttrs: {
+    tabindex: item.disabled ? -1 : 0,
+    role: item.meta?.children ? 'tooltip' : null
+  },
+  elementTag: item.meta?.header ? 'h1' : 'div'
+}))
 </script>
 
 <template>
   <SelectableItems :items="items" :itemDefaults="itemDefaults"/>
 </template>
 ```
+
 ## Context
 
 Context is an object of functions, you can access it via `setup` prop and `template ref`.

--- a/playground/examples/keyboard/index.vue
+++ b/playground/examples/keyboard/index.vue
@@ -10,15 +10,16 @@ import {
 import useKey from '../../composables/useKey';
 import type { DemoItemMetaData } from '../../types';
 
-const itemDefaults = createItemDefaults({
+const itemDefaults = createItemDefaults((item) => ({
   elementTag: 'button',
   elementAttrs: {
-    tabindex: 0,
+    tabindex: item.disabled ? -1 : 0,
+    disabled: item.disabled ? true : null,
     style: {
       outline: 'none',
     },
   },
-});
+}));
 
 function setupHandler(ctx: Context) {
   useKey(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,3 +20,7 @@ export const ClassNames = {
   Focused: `${libName}-item-focused`,
   Disabled: `${libName}-item-disabled`,
 } as const;
+
+export const READONLY_EMPTY_OBJECT = Object.freeze(Object.create(null)) as Readonly<
+  Record<string, never>
+>;

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -112,16 +112,17 @@ export function isOr<Value, Or>(value: Value, is: (value: unknown) => boolean, o
   return is(value) ? value : or;
 }
 
-export function createItemDefaults({
-  elementAttrs = null,
-  elementTag = null,
-  wrapperComponentOrTag = null,
-  wrapperProps = null,
-}: NullablePartial<ItemDefaults> = {}): NullablePartial<ItemDefaults> {
+export function createItemDefaults<Meta = unknown>(
+  param: NullablePartial<ItemDefaults> | ((item: Item<Meta>) => NullablePartial<ItemDefaults>),
+) {
+  if (typeof param === 'function') {
+    return param;
+  }
+
+  const { wrapperComponentOrTag = null, ...others } = param;
+
   return {
-    elementAttrs,
-    elementTag,
-    wrapperProps,
+    ...others,
     wrapperComponentOrTag: isComponent(wrapperComponentOrTag)
       ? markRaw(wrapperComponentOrTag)
       : wrapperComponentOrTag,

--- a/tests/component.test.ts
+++ b/tests/component.test.ts
@@ -191,7 +191,7 @@ describe('main tests', () => {
     }
   });
 
-  it('should text default options', async () => {
+  async function testItemDefaults(useCallback = false) {
     const items = [
       item({
         key: 'q',
@@ -223,14 +223,15 @@ describe('main tests', () => {
 
     const Wrapper: FunctionalComponent = (_props, { slots }) => h('div', null, slots.default());
 
-    const defaults = createItemDefaults({
+    const defaultsObj = {
       wrapperComponentOrTag: Wrapper,
       wrapperProps: { class: 'wrapper-yes' },
       elementAttrs: {
         surname: 'yazici',
       },
       elementTag: 'span',
-    });
+    };
+    const defaults = createItemDefaults(useCallback ? () => defaultsObj : defaultsObj);
 
     await wrapper.setProps({ items, itemDefaults: defaults });
 
@@ -258,5 +259,8 @@ describe('main tests', () => {
         .findAll('.vue-selectable-items-item') //
         .every(({ element }) => element.tagName === 'BUTTON'),
     ).toBe(true);
-  });
+  }
+
+  it('should test default options object', () => testItemDefaults());
+  it('should test default options callback', () => testItemDefaults(true));
 });


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  - Feature


* **What is the new behavior (if this is a feature change)?**
  - Now `createıtemDefaults` accepts a callback and `item` is passed as parameter, this will allow users to create dynamic defaults.
